### PR TITLE
fix issue about event's coordinate changed

### DIFF
--- a/CoolDragAndDrop/src/com/example/cooldraganddrop/SpanVariableGridView.java
+++ b/CoolDragAndDrop/src/com/example/cooldraganddrop/SpanVariableGridView.java
@@ -541,10 +541,8 @@ public class SpanVariableGridView extends AdapterView<BaseAdapter> {
 	@Override
 	public boolean dispatchTouchEvent(MotionEvent event) {
 
-		final boolean result = super.dispatchTouchEvent(event);
-
 		if (getChildCount() == 0) {
-			return result;
+			return super.dispatchTouchEvent(event);
 		}
 
 		switch (event.getAction()) {
@@ -569,7 +567,7 @@ public class SpanVariableGridView extends AdapterView<BaseAdapter> {
 			break;
 		}
 
-		return result;
+		return super.dispatchTouchEvent(event);
 	}
 
 }


### PR DESCRIPTION
fix event's x coordinate and y coordinate has changed  after invoke super.dispatchTouchEvent(event)
this issue cause  method startTouch(event), event's coordiante is not the real coordinate;and then cause
pointToPosition() always return 0;so if I invoke onItemClick method ,the view is always item0;
